### PR TITLE
adding file to fix line feeds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.f90 text
+*.md text
+*.c text
+*.cpp text
+*.h text
+*.py text
+*.pyi text
+*.bdf text
+*.txt text
+*.triq text
+*.c3d text
+*.dat text
+*.inp text
+*.smesh text
+*.ele text
+*.node text
+*.su2 text
+*.wgs text
+*.grid text
+*.mapbc text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.op2 binary
+*.op4 binary
+*.plt binary
+*.tri binary
+*.cogsg binary
+*.pptx binary
+*.docx binary
+*.b8.ugrid binary
+*.exe binary


### PR DESCRIPTION
This fix the carriage return for all the files.  Zack had a problem merging the op2 because of this issue.  It showed that I changed ~1000 files, but when I probably changed much closer to 40.

There are 3 choices:
 1. Do nothing.  Anyone is allowed to change the the line ending making it look like there are far more differences than they're actually are.  It's not something that anyone does intentionally, but is rather a setting in whatever text editor they're using.  Windows uses \n\r (line feed & carriage return), while Linux uses \n.  
 2. Use \n\r.
 3. Use \n.  What this pull request uses.

This special file allows you to set the line ending per file, so regardless of what you make it with, it will upload and download correctly.  This is changable later with an easily understand text file.   It even supports binary files (files that shouldn't be touched), so no worries there.

From checking ~20 files, they're all using line feeds (\n), so I'd say that's the way we should go.  That's the one I'd recommend anyways (it's the standard).