### PR TITLE
Report download errors for SuperLU and libf2c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,17 @@ if(NOT EXISTS ${SUPERLU_FN})
     STATUS
     "Downloading SuperLU ${SUPERLU_VERSION} source from ${SUPERLU_URL}..."
   )
-  file(DOWNLOAD ${SUPERLU_URL} ${SUPERLU_FN} TIMEOUT 60)
-  message(STATUS "Done downloading SuperLU.")
+  file(DOWNLOAD ${SUPERLU_URL} ${SUPERLU_FN} TIMEOUT 60 STATUS DOWNLOAD_STATUS)
+  # Check if download was successful.
+  list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+  list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+  if(${STATUS_CODE} EQUAL 0)
+    message(STATUS "Done downloading SuperLU.")
+  else()
+    # Exit CMake if the download failed, printing the error message.
+    file(REMOVE ${SUPERLU_FN})
+    message(FATAL_ERROR "Error occurred during download of SuperLU: ${ERROR_MESSAGE}")
+  endif()
 endif()
 
 # extract superlu source
@@ -56,8 +65,17 @@ set(F2C_URL "https://www.netlib.org/${F2C_FN}")
 if(NOT EXISTS ${F2C_DIR})
   message(STATUS "Downloading libf2c source from ${F2C_URL}...")
   make_directory("${F2C_DIR}")
-  file(DOWNLOAD ${F2C_URL} ${F2C_FN} TIMEOUT 60)
-  message(STATUS "Done downloading libf2c.")
+  file(DOWNLOAD ${F2C_URL} ${F2C_FN} TIMEOUT 60 STATUS DOWNLOAD_STATUS)
+  # Check if download was successful.
+  list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+  list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+  if(${STATUS_CODE} EQUAL 0)
+    message(STATUS "Done downloading libf2c.")
+  else()
+    # Exit CMake if the download failed, printing the error message.
+    file(REMOVE_RECURSE ${F2C_DIR})
+    message(FATAL_ERROR "Error occurred during download of libf2c: ${ERROR_MESSAGE}")
+  endif()
 endif()
 
 # extract libf2c source


### PR DESCRIPTION
In the current CMakeLists.txt file of the master branch, CMake ignores any download errors and simply continue on with the script, later raising an error when the expected files from the downloads are not located.  The raised error is only a result of the missing files and therefore doesn't detail the download error.

This pull requests adds code to get the status of the downloads for SuperLU and libf2c.  If successful, CMake reports a successful download and continues.  If it fails, CMake will report the error message from the failed download, remove any incomplete files/directories, such as an empty (0 byte) superlu-5.2.2.tar.gz and the f2c directory which would contain an empty libf2c.zip file, and then exits the script.

I believe the additional output of the download error message will simplify debugging build errors.  In my case, superlu-5.2.2.tar.gz and libf2c.zip were always 0 bytes.  After modifying CMakeLists.txt to report the download status, it showed an 'Unsupported protocol' error. From that I was able to determine that my CMake was compiled without OpenSSL.  Recompiling CMake with OpenSSL enabled solved the error.